### PR TITLE
Ignore koala.sqlite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ develop-eggs
 cover
 AUTORS
 ChangeLog
+koala/openstack/common/db/koala.sqlite


### PR DESCRIPTION
Koala-manage generates a sqlite.db in the project, so we should
ignore it.
