### PR TITLE
Fix get total time error in python 2.6

### DIFF
--- a/koala/billing/base.py
+++ b/koala/billing/base.py
@@ -150,6 +150,17 @@ class Resource(object):
 
         return start_at
 
+    def get_total_seconds(start_at, end_at):
+        """What the fuck.
+
+        datetime.deltatime does not have attribute total_seconds in python 2.6.
+        """
+        time_delta = end_at - start_at
+        if hasattr(time_delta, 'total_seconds'):
+            return time_delta.total_seconds()
+        else:
+            return time_delta.seconds + time_delta.days * 3600 * 24
+
     def billing_resource(self):
         """Billing the resource and generate billing records.
 

--- a/koala/billing/image.py
+++ b/koala/billing/image.py
@@ -52,7 +52,7 @@ class Image(base.Resource):
         resource = self.get_resource()
         unit_price = self.get_price()
         start_at = self.get_start_at()
-        deta_time = (self.event_time - start_at).total_seconds() / 3600.0
+        deta_time = self.get_total_seconds(start_at, self.event_time) / 3600.0
 
         record = {}
         updated_resource = {}

--- a/koala/billing/router.py
+++ b/koala/billing/router.py
@@ -42,7 +42,7 @@ class Router(base.Resource):
         resource = self.get_resource()
         unit_price = self.get_price()
         start_at = self.get_start_at()
-        deta_time = (self.event_time - start_at).total_seconds() / 3600.0
+        deta_time = self.get_total_seconds(start_at, self.event_time) / 3600.0
         record = {}
         updated_resource = {}
         record_description = self.resource_type + ' ' + self.event_type

--- a/koala/billing/volume.py
+++ b/koala/billing/volume.py
@@ -50,7 +50,7 @@ class Volume(base.Resource):
         resource = self.get_resource()
         unit_price = self.get_price()
         start_at = self.get_start_at()
-        deta_time = (self.event_time - start_at).total_seconds() / 3600.0
+        deta_time = self.get_total_seconds(start_at, self.event_time) / 3600.0
         record_description = self.resource_type + ' ' + self.event_type
         record = {}
         updated_resource = {}

--- a/koala/billing/volume_snapshot.py
+++ b/koala/billing/volume_snapshot.py
@@ -47,7 +47,7 @@ class VolumeSnapshot(base.Resource):
         resource = self.get_resource()
         unit_price = self.get_price()
         start_at = self.get_start_at()
-        deta_time = (self.event_time - start_at).total_seconds() / 3600.0
+        deta_time = self.get_total_seconds(start_at, self.event_time) / 3600.0
 
         record = {}
         updated_resource = {}


### PR DESCRIPTION
Python datetime.deltatime does not have attribute total_seconds in
python 2.6.
