### PR TITLE
Fix bug of missing resize event

### DIFF
--- a/koala/billing/base.py
+++ b/koala/billing/base.py
@@ -223,6 +223,7 @@ class Resource(object):
         updated_resource = {}
         total_consumption = self.exist_resource.consumption + consumption
         updated_resource['consumption'] = total_consumption
+        updated_resource['content'] = jsonutils.dumps(self.content)
 
         if self.event_type != 'exists':
             updated_resource['description'] = description

--- a/koala/billing/instance.py
+++ b/koala/billing/instance.py
@@ -80,15 +80,21 @@ class Instance(base.Resource):
         total_seconds = self.get_total_seconds(self.start_at, self.event_time)
         delta_time = total_seconds / 3600.0
 
+        pre_content = jsonutils.loads(self.exist_resource.content)
         if self.event_type == 'resize':
-            pre_content = jsonutils.loads(self.exist_resource.content)
             vcpu = pre_content.get('vcpu', 0)
             ram = pre_content.get('ram', 0)
             disk = pre_content.get('disk', 0)
         else:
-            vcpu = self.vcpu
-            ram = self.ram
-            disk = self.disk
+            if (self.vcpu != pre_content.get('vcpu', 0) or
+                self.ram != pre_content.get('ram', 0) or
+                self.disk != pre_content.get('disk', 0)):
+                # TBD(fandeliang)
+                # Log.warning("Miss resize event.")
+                pass
+            vcpu = min(self.vcpu, pre_content.get('vcpu', 0))
+            ram = min(self.ram, pre_content.get('ram', 0))
+            disk = min(self.disk, pre_content.get('disk', 0))
 
         previous_status = self.get_instance_previous_status()
 

--- a/koala/billing/volume.py
+++ b/koala/billing/volume.py
@@ -53,11 +53,16 @@ class Volume(base.Resource):
         total_seconds = self.get_total_seconds(self.start_at, self.event_time)
         delta_time = total_seconds / 3600.0
 
+        pre_content = jsonutils.loads(self.exist_resource.content)
         if self.event_type == 'resize':
-            pre_content = jsonutils.loads(self.exist_resource.content)
             size = pre_content.get('size', 0)
         else:
-            size = self.size
+            pre_size = pre_content.get('size', 0)
+            if pre_size != self.size:
+                # TBD(fandeliang)
+                # Log.warning("Miss resize event.")
+                pass
+            size = min(self.size, pre_size)
 
         consumption = self.unit_price * delta_time * size
 


### PR DESCRIPTION
When a resize event is missing, we should calculate the consumption
with the least size.
